### PR TITLE
Fix 8-bit WAV playback using unsigned format SND_PCM_FORMAT_U8

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -486,7 +486,7 @@ AudioObject * audioInit(AudioConfiguration *configuration) {
     // Determine the pcm format from the bit rate
     snd_pcm_format_t format;
     switch (audioObject->riffData.bitsPerSample) {
-        case 8:  format = SND_PCM_FORMAT_S8;         break;
+        case 8:  format = SND_PCM_FORMAT_U8;         break;
         case 16: format = SND_PCM_FORMAT_S16_LE;     break;
         case 24: format = SND_PCM_FORMAT_S24_3LE;    break;
         case 32: format = SND_PCM_FORMAT_S32_LE;     break;


### PR DESCRIPTION
This pull request fixes the issue with 8-bit WAV file playback failing due to an incorrect signed format assumption. The change replaces `SND_PCM_FORMAT_S8` with `SND_PCM_FORMAT_U8` when setting the PCM hardware parameters for 8-bit audio, ensuring compatibility with the unsigned integer format typically used in 8-bit WAV files.

Resolves #8 