### PR TITLE
Remove redundant type casts in _resetError function

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -186,9 +186,9 @@ typedef struct {
 } _AudioObject;
 
 void _resetError(_AudioObject *_self) {
-    ((_AudioObject*)_self)->error->type = AUDIO_ERROR_NO_ERROR;
-    ((_AudioObject*)_self)->error->level = AUDIO_ERROR_LEVEL_INFO;
-    ((_AudioObject*)_self)->error->alsaErrorNumber = 0;
+    _self->error->type = AUDIO_ERROR_NO_ERROR;
+    _self->error->level = AUDIO_ERROR_LEVEL_INFO;
+    _self->error->alsaErrorNumber = 0;
 }
 
 void _waitForBarriers(_AudioObject *_self) {


### PR DESCRIPTION
## Description
This PR removes unnecessary type casts in the `_resetError` function within the `audio.c` file. These casts were redundant as the `_self` parameter is already of type `_AudioObject *`.

## Changes
- Removed three redundant `(_AudioObject*)` casts in the `_resetError` function.

## Motivation and Context
Removing these casts improves code readability and maintainability while aligning with modern C programming best practices. It also increases consistency with the rest of the codebase where such casts are not used in similar contexts.

## Detailed Considerations
The decision to remove these casts was based on several factors:

1. **Code Consistency**: A thorough review of `audio.c` revealed that similar redundant casts are not used elsewhere in the file. Removing them improves overall code consistency

2. **Current Best Practices**: C programming best practices emphasize clarity and minimalism. Unnecessary casts are generally discouraged as they can introduce errors, clutter the code, and potentially hide type mismatches

3. **Future-proofing**: While the possibility of future changes affecting this function was considered, that risk appears low as the structure of the `_AudioObject` and its associated functions already appear stable and well-designed

4. **Readability**: The function becomes more straightforward and easier to understand without the redundant casts